### PR TITLE
Add support for multiple independent collections ISSUE=5706

### DIFF
--- a/conf/config.xml.example
+++ b/conf/config.xml.example
@@ -14,17 +14,13 @@
     filter_name [optional]: If filtering results from SIMP, what field to filter on eg "node"
     filter_value [optional]: If filtering results from SIMP, the value of the field to filter eg ".*chic.*".
                              This is passed in as a string representing a regular expression.
-  -->
-  <collection interval='60' composite-name='interfaces' filter_name='' filter_value='' />
-
-  <!--
-    Hosts information:
-    Workers: How many Workers to create
+    workers: How many Workers to create
     Host list: List of hosts to collect on
     (Hosts will be divided up among the number of configured workers)
   -->
-  <hosts workers="1">
+  <collection interval='60' composite-name='interfaces' filter_name='' filter_value='' workers='1'>
     <host>host.name.net</host>
     <host>host2.name.net</host>
-  </hosts>
+  </collection>
+
 </config>

--- a/conf/config.xml.example
+++ b/conf/config.xml.example
@@ -9,6 +9,7 @@
 
   <!-- 
     Collection details:
+    tsds_type: TSDS measurement type we will send the results from Comp as
     interval: Polling interval - how frequently we will ask for data from Comp
     composite-name: Composite name from Comp we are interested in
     filter_name [optional]: If filtering results from SIMP, what field to filter on eg "node"
@@ -18,7 +19,7 @@
     Host list: List of hosts to collect on
     (Hosts will be divided up among the number of configured workers)
   -->
-  <collection interval='60' composite-name='interfaces' filter_name='' filter_value='' workers='1'>
+  <collection tsds_type='interface' interval='60' composite-name='interfaces' filter_name='' filter_value='' workers='1'>
     <host>host.name.net</host>
     <host>host2.name.net</host>
   </collection>

--- a/lib/SIMP/Collector/Master.pm
+++ b/lib/SIMP/Collector/Master.pm
@@ -122,7 +122,7 @@ sub _load_config {
             $self->logger->error('No or invalid TSDS measurement type defined for a collection! Exiting.');
             $should_die = 1;
         }
-        if (!defined($collection->{'interval'}) {
+        if (!defined($collection->{'interval'})) {
             $self->logger->error('Interval not defined for a collection! Exiting.');
             $should_die = 1;
         } elsif ($collection->{'interval'} < 1) {

--- a/lib/SIMP/Collector/Master.pm
+++ b/lib/SIMP/Collector/Master.pm
@@ -208,9 +208,7 @@ sub _create_workers_for_one_collection {
     }
 
     # Spawn workers
-    for (my $worker_id = 0; $worker_id < $collection->{'workers'}; $worker_id++) {
-	my $proc;
-	my $init_proc;
+    foreach my $worker_id (keys %hosts_by_worker) {
 	my $worker_name = "$collection->{'composite-name'}_$worker_id";
 
 	$self->_create_worker( name       => $worker_name,

--- a/lib/SIMP/Collector/Master.pm
+++ b/lib/SIMP/Collector/Master.pm
@@ -116,30 +116,32 @@ sub _load_config {
 
     # Sanity-check some of the collection parameters
     foreach my $collection (@{$self->collections}) {
+        my $should_die = 0;
+
         if (!defined($collection->{'interval'}) {
             $self->logger->error('Interval not defined for a collection! Exiting.');
-            die;
-        }
-        if ($collection->{'interval'} < 1) {
+            $should_die = 1;
+        } elsif ($collection->{'interval'} < 1) {
             $self->logger->error("Invalid interval '$collection->{'interval'}'! Exiting.");
-            die;
+            $should_die = 1;
         }
         if (!defined($collection->{'composite-name'})) {
             $self->logger->error('Composite for a collection not defined! Exiting.');
-            die;
+            $should_die = 1;
         }
         if ($collection->{'filter_value'} xor $collection->{'filter_name'}) {
             $self->logger->error('If filtering, both filter_name and filter_value must be specified! Exiting.');
-            die;
+            $should_die = 1;
         }
         if (!defined($collection->{'workers'})) {
             $self->logger->error('Number of workers not defined for a collection! Exiting.');
-            die;
-        }
-        if ($collection->{'workers'} < 1) {
+            $should_die = 1;
+        } elsif ($collection->{'workers'} < 1) {
             $self->logger->error("Invalid number of workers '$collection->{'workers'}'! Exiting.");
-            die;
+            $should_die = 1;
         }
+
+        die if $should_die;
 
         $collection->{'host'} = [] if !defined($collection->{'host'});
     }

--- a/lib/SIMP/Collector/Master.pm
+++ b/lib/SIMP/Collector/Master.pm
@@ -118,6 +118,10 @@ sub _load_config {
     foreach my $collection (@{$self->collections}) {
         my $should_die = 0;
 
+        if (!defined($collection->{'tsds_type'}) || ($collection->{'tsds_type'} eq '')) {
+            $self->logger->error('No or invalid TSDS measurement type defined for a collection! Exiting.');
+            $should_die = 1;
+        }
         if (!defined($collection->{'interval'}) {
             $self->logger->error('Interval not defined for a collection! Exiting.');
             $should_die = 1;
@@ -243,6 +247,7 @@ sub _create_worker{
 						       hosts => $params{'hosts'},
 						       simp_config => $self->simp_config,
 						       tsds_config => $self->tsds_config,
+                                                       tsds_type => $collection->{'tsds_type'},
 						       interval => $collection->{'interval'},
 						       filter_name => $collection->{'filter_name'},
 						       filter_value => $collection->{'filter_value'}

--- a/lib/SIMP/Collector/Master.pm
+++ b/lib/SIMP/Collector/Master.pm
@@ -204,7 +204,7 @@ sub _create_workers_for_one_collection {
     my $idx = 0;
 
     # Divide up hosts in config among number of workers defined in config
-    foreach my $host (@{$collection->{'host'}}}) {
+    foreach my $host (@{$collection->{'host'}}) {
         next if !defined($host) || (ref($host) ne '');
 	push(@{$hosts_by_worker{$idx}}, $host);
 	$idx++;

--- a/lib/SIMP/Collector/Worker.pm
+++ b/lib/SIMP/Collector/Worker.pm
@@ -177,8 +177,8 @@ sub _process_host {
     # Take data from Comp and "package" for a post to TSDS
     foreach my $node_name (keys %{$res->{'results'}}) {
 
-	$self->logger->error("Name: " . Dumper($node_name));
-	$self->logger->error("Value: " . Dumper($res->{'results'}->{$node_name}));
+	$self->logger->debug($self->worker_name . ' Name: ' . Dumper($node_name));
+	$self->logger->debug($self->worker_name . ' Value: ' . Dumper($res->{'results'}->{$node_name}));
 
 	my $data = $res->{'results'}->{$node_name};
 	foreach my $datum_name (keys %{$data}) {

--- a/simp-collector.spec
+++ b/simp-collector.spec
@@ -63,7 +63,7 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %files
-%defattr(-,root,root,-)
+%defattr(644,root,root,755)
 %attr(755,root,root) %{execdir}/simp-collector
 %if 0%{?rhel} == 7
 %attr(644,root,root) /etc/systemd/system/simp-collector.service

--- a/simp-collector.spec
+++ b/simp-collector.spec
@@ -18,7 +18,7 @@ Requires: perl(Data::Dumper), perl(Getopt::Long), perl(AnyEvent), perl(Moo), per
 %define sysconfdir /etc/sysconfig
 
 %description
-This program pulls SNMP network interface rate data from Simp and publishes to TSDS.
+This program pulls SNMP-derived data from Simp and publishes it to TSDS.
 
 %pre
 /usr/bin/getent group simp-collector > /dev/null || /usr/sbin/groupadd -r simp-collector


### PR DESCRIPTION
This pull request includes:

* changing things so that there can be multiple collections, each with its own polling composite, host list, etc., and each controlled by a separate `<collection>` tag
* making configurable the TSDS measurement type that data in a collection is pushed as
* some miscellaneous improvements and clean-up

This pull request makes a non-backward-compatible change in the effective XML schema of `config.xml`.