### PR TITLE
Add ability to keep simp-collector from pushing a datum to TSDS unless certain values are defined ISSUE=6472

### DIFF
--- a/conf/config.xml.example
+++ b/conf/config.xml.example
@@ -15,6 +15,8 @@
     filter_name [optional]: If filtering results from SIMP, what field to filter on eg "node"
     filter_value [optional]: If filtering results from SIMP, the value of the field to filter eg ".*chic.*".
                              This is passed in as a string representing a regular expression.
+    required_values [optional]: A comma-delimited list of value fields. If any value in the list isn't
+                                defined for some result from Comp, that result isn't sent on to TSDS.
     workers: How many Workers to create
     Host list: List of hosts to collect on
     (Hosts will be divided up among the number of configured workers)

--- a/lib/SIMP/Collector/Master.pm
+++ b/lib/SIMP/Collector/Master.pm
@@ -228,34 +228,35 @@ sub _create_worker{
     my %params = @_;
 
     my $collection = $params{'collection'};
-    
-    my $init_proc = AnyEvent::Subprocess->new( on_completion => sub {
-	$self->logger->error("Child " . $params{'name'} . " has died");
-	#do something to restart
-	#pop the worker off the queue
-	$self->_create_worker( %params );
-					       },
-					       code => sub {
-						   use GRNOC::Log;
-						   use SIMP::Collector::Worker;
-						   
-						   $self->logger->info("Creating Collector for " . $params{'name'});
-						   my $worker = SIMP::Collector::Worker->new(
-						       worker_name => $params{'name'},
-						       logger => $self->logger,
-						       composite_name => $collection->{'composite-name'},
-						       hosts => $params{'hosts'},
-						       simp_config => $self->simp_config,
-						       tsds_config => $self->tsds_config,
-                                                       tsds_type => $collection->{'tsds_type'},
-						       interval => $collection->{'interval'},
-						       filter_name => $collection->{'filter_name'},
-						       filter_value => $collection->{'filter_value'}
-						       );
-						   
-						   $worker->run();
-					       });
-    
+
+    my $init_proc = AnyEvent::Subprocess->new(
+        on_completion => sub {
+            $self->logger->error("Child " . $params{'name'} . " has died");
+            #do something to restart
+            #pop the worker off the queue
+            $self->_create_worker( %params );
+        },
+        code => sub {
+            use GRNOC::Log;
+            use SIMP::Collector::Worker;
+
+            $self->logger->info("Creating Collector for " . $params{'name'});
+            my $worker = SIMP::Collector::Worker->new(
+                worker_name => $params{'name'},
+                logger => $self->logger,
+                composite_name => $collection->{'composite-name'},
+                hosts => $params{'hosts'},
+                simp_config => $self->simp_config,
+                tsds_config => $self->tsds_config,
+                tsds_type => $collection->{'tsds_type'},
+                interval => $collection->{'interval'},
+                filter_name => $collection->{'filter_name'},
+                filter_value => $collection->{'filter_value'},
+            );
+            $worker->run();
+        }
+    );
+
     my $proc = $init_proc->run();
     push(@{$self->children}, $proc);
 }

--- a/lib/SIMP/Collector/Master.pm
+++ b/lib/SIMP/Collector/Master.pm
@@ -240,6 +240,9 @@ sub _create_worker{
             use GRNOC::Log;
             use SIMP::Collector::Worker;
 
+            my $required_vals = $collection->{'required_values'};
+            $required_vals = '' if !defined($required_vals);
+
             $self->logger->info("Creating Collector for " . $params{'name'});
             my $worker = SIMP::Collector::Worker->new(
                 worker_name => $params{'name'},
@@ -252,6 +255,7 @@ sub _create_worker{
                 interval => $collection->{'interval'},
                 filter_name => $collection->{'filter_name'},
                 filter_value => $collection->{'filter_value'},
+                required_value_fields => [ split(',', $required_vals) ],
             );
             $worker->run();
         }

--- a/simp-collector.spec
+++ b/simp-collector.spec
@@ -10,7 +10,20 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch:noarch
 
 BuildRequires: perl
-Requires: perl(Data::Dumper), perl(Getopt::Long), perl(AnyEvent), perl(Moo), perl(Types::Standard), perl(JSON::XS), perl(Proc::Daemon), perl(GRNOC::Config), perl(GRNOC::WebService::Client), perl(GRNOC::RabbitMQ::Client), perl(GRNOC::Log), perl(Parallel::ForkManager), perl(MooseX::Clone)
+Requires: perl(AnyEvent)
+Requires: perl(Data::Dumper)
+Requires: perl(Getopt::Long)
+Requires: perl(JSON::XS)
+Requires: perl(List::MoreUtils)
+Requires: perl(Moo)
+Requires: perl(MooseX::Clone)
+Requires: perl(Parallel::ForkManager)
+Requires: perl(Proc::Daemon)
+Requires: perl(Types::Standard)
+Requires: perl(GRNOC::Config)
+Requires: perl(GRNOC::WebService::Client)
+Requires: perl(GRNOC::RabbitMQ::Client)
+Requires: perl(GRNOC::Log)
 
 %define execdir /usr/sbin
 %define configdir /etc/simp/collector


### PR DESCRIPTION
We've run into cases where we'd rather simp-collector _not_ push a datum to TSDS unless certain values in the datum are all defined. This PR adds the ability to do that.

Changing (in `config.xml`)

```xml
  <collection tsds_type='optical' interval='30' composite-name='rtr_light' workers='1'>
    <host>rtr.pop.example.net</host>
  </collection>
```

to

```xml
  <collection tsds_type='optical' interval='30' composite-name='rtr_light' workers='1'
              required_values='rxpower,txpower'>
    <host>rtr.pop.example.net</host>
  </collection>
```

informs simp-collector that it should collect the same way it would with the first stanza, _except_ that a datum with a null `rxpower` and/or `txpower` will not get pushed to TSDS.

I've tested an example instance of the code as it stands in my branch, and it looks good!